### PR TITLE
fixup: correct preview URL reported in pull requests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,10 +64,10 @@ pipeline {
       }
       post {
         success {
-          recordDeployment('jenkins-infra', 'stats.jenkins.io', pullRequest.head, 'success', "https://deploy-preview-${CHANGE_ID}--stats.jenkins.io.netlify.app")
+          recordDeployment('jenkins-infra', 'stats.jenkins.io', pullRequest.head, 'success', "https://deploy-preview-${CHANGE_ID}--stats-jenkins-io.netlify.app")
         }
         failure {
-          recordDeployment('jenkins-infra', 'stats.jenkins.io', pullRequest.head, 'failure', "https://deploy-preview-${CHANGE_ID}--stats.jenkins.io.netlify.app")
+          recordDeployment('jenkins-infra', 'stats.jenkins.io', pullRequest.head, 'failure', "https://deploy-preview-${CHANGE_ID}--stats-jenkins-io.netlify.app")
         }
       }
     }


### PR DESCRIPTION
This PR fixes the preview URL reported in pull requests.

```diff
- https://deploy-preview-7--stats.jenkins.io.netlify.app/
+ https://deploy-preview-7--stats-jenkins-io.netlify.app/
```

Fixup of:
- #3 

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4132#issuecomment-2167717401