### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Order is important. The last matching pattern has the most precedence.
+* @jenkins-infra/stats-jenkins-io


### PR DESCRIPTION
This PR adds a CODEOWNERS file to automatically add @jenkins-infra/stats-jenkins-io team as reviewer on pull requests.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4132#issuecomment-2167717401