### PR TITLE
chore: update website title

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8" />
         <link rel="icon" type="image/svg+xml" href="/jenkins.svg" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Jenkins infra-statistics</title>
+        <title>Jenkins Statistics</title>
         <!-- Load necessary scripts for jio-navbar -->
         <script type="module" src="https://unpkg.com/@jenkinsci/jenkins-io-components?module"></script>
         <script src="https://unpkg.com/@webcomponents/webcomponentsjs@2.6.0/webcomponents-loader.js"></script>


### PR DESCRIPTION
This PR updates the website title from "Jenkins infra-statistics" to "Jenkins Statistics" appearing as tab name in browsers.