### PR TITLE
feat: dedicated previews pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,30 +47,6 @@ pipeline {
       }
     }
 
-    stage('Deploy PR to preview site') {
-      when {
-        allOf{
-          changeRequest target: 'main'
-          // Only deploy from infra.ci.jenkins.io
-          expression { infra.isInfra() }
-        }
-      }
-      environment {
-        NETLIFY_AUTH_TOKEN = credentials('netlify-auth-token')
-      }
-      steps {
-        sh 'netlify-deploy --draft=true --siteName "stats-jenkins-io" --title "Preview deploy for ${CHANGE_ID}" --alias "deploy-preview-${CHANGE_ID}" -d ./dist'
-      }
-      post {
-        success {
-          recordDeployment('jenkins-infra', 'stats.jenkins.io', pullRequest.head, 'success', "https://deploy-preview-${CHANGE_ID}--stats-jenkins-io.netlify.app")
-        }
-        failure {
-          recordDeployment('jenkins-infra', 'stats.jenkins.io', pullRequest.head, 'failure', "https://deploy-preview-${CHANGE_ID}--stats-jenkins-io.netlify.app")
-        }
-      }
-    }
-
     stage('Deploy to production') {
       when {
         allOf{

--- a/Jenkinsfile_previews
+++ b/Jenkinsfile_previews
@@ -1,0 +1,55 @@
+pipeline {
+  options {
+    timeout(time: 60, unit: 'MINUTES')
+    ansiColor('xterm')
+    disableConcurrentBuilds(abortPrevious: true)
+    buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '5', numToKeepStr: '5')
+  }
+
+  agent {
+    label 'linux-arm64-docker || arm64linux'
+  }
+
+  stages {
+    stage('Install dependencies') {
+      steps {
+        sh '''
+        asdf install
+        npm install
+        '''
+      }
+    }
+
+    stage('Build') {
+      steps {
+        sh '''
+        npm run build
+        '''
+      }
+    }
+
+    stage('Deploy PR to preview site') {
+      when {
+        allOf{
+          changeRequest target: 'main'
+          // Only deploy from infra.ci.jenkins.io
+          expression { infra.isInfra() }
+        }
+      }
+      environment {
+        NETLIFY_AUTH_TOKEN = credentials('netlify-auth-token')
+      }
+      steps {
+        sh 'netlify-deploy --draft=true --siteName "stats-jenkins-io" --title "Preview deploy for ${CHANGE_ID}" --alias "deploy-preview-${CHANGE_ID}" -d ./dist'
+      }
+      post {
+        success {
+          recordDeployment('jenkins-infra', 'stats.jenkins.io', pullRequest.head, 'success', "https://deploy-preview-${CHANGE_ID}--stats-jenkins-io.netlify.app")
+        }
+        failure {
+          recordDeployment('jenkins-infra', 'stats.jenkins.io', pullRequest.head, 'failure', "https://deploy-preview-${CHANGE_ID}--stats-jenkins-io.netlify.app")
+        }
+      }
+    }
+  }
+}

--- a/Jenkinsfile_previews
+++ b/Jenkinsfile_previews
@@ -12,6 +12,13 @@ pipeline {
 
   stages {
     stage('Install dependencies') {
+      when {
+        allOf{
+          changeRequest target: 'main'
+          // Only deploy from infra.ci.jenkins.io
+          expression { infra.isInfra() }
+        }
+      }
       steps {
         sh '''
         asdf install
@@ -21,6 +28,13 @@ pipeline {
     }
 
     stage('Build') {
+      when {
+        allOf{
+          changeRequest target: 'main'
+          // Only deploy from infra.ci.jenkins.io
+          expression { infra.isInfra() }
+        }
+      }
       steps {
         sh '''
         npm run build


### PR DESCRIPTION
This PR adds an infra.ci.jenkins.io pipeline dedicated to previews that can be triggered by any contributor even if they don't have write permission on the repository.

Needs:
- https://github.com/jenkins-infra/kubernetes-management/pull/5345

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4132#issuecomment-2185272935