### PR TITLE
feat: update PluginCard downloads # (add thousands comma)

### DIFF
--- a/src/components/PluginTrends/Layout/PluginCard.tsx
+++ b/src/components/PluginTrends/Layout/PluginCard.tsx
@@ -21,7 +21,12 @@ const PluginCard: React.FC<PluginCardProps> = ({ plugin }) => {
             (sum, installations) => sum + installations,
             0
         )
-        return (totalInstallations / 1000).toFixed(1) + 'K'
+        return (
+            (totalInstallations / 1000).toLocaleString(undefined, {
+                minimumFractionDigits: 0,
+                maximumFractionDigits: 1,
+            }) + 'K'
+        )
     }, [plugin.chartData])
 
     return (


### PR DESCRIPTION
makes the number more visually appealing by adding a comma in the thousands place.

![Screenshot 2024-06-26 at 5 40 43 PM](https://github.com/jenkins-infra/stats.jenkins.io/assets/64103471/561074a1-a32a-4f48-a020-484ba55d493f)
