### PR TITLE
feat: retrieve data from infra-statistics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# infra-statistics
+src/data/infra-statistics

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,10 @@ pipeline {
     label 'linux-arm64-docker || arm64linux'
   }
 
+  environment {
+    INFRASTATISTICS_LOCATION = 'src/data/infra-statistics'
+  }
+
   stages {
     stage('Check for typos') {
       steps {
@@ -35,6 +39,17 @@ pipeline {
       steps {
         sh '''
         npm run lint
+        '''
+      }
+    }
+
+    stage('Retrieve data from infra-statistics') {
+      steps {
+        sh '''
+        curl --silent --fail --output infra-statistics-gh-pages.zip --location "https://github.com/jenkins-infra/infra-statistics/archive/refs/heads/gh-pages.zip"
+        unzip -n infra-statistics-gh-pages.zip
+        mv infra-statistics-gh-pages "${INFRASTATISTICS_LOCATION}"
+        rm infra-statistics-gh-pages.zip
         '''
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,12 +45,7 @@ pipeline {
 
     stage('Retrieve data from infra-statistics') {
       steps {
-        sh '''
-        curl --silent --fail --output infra-statistics-gh-pages.zip --location "https://github.com/jenkins-infra/infra-statistics/archive/refs/heads/gh-pages.zip"
-        unzip -n infra-statistics-gh-pages.zip
-        mv infra-statistics-gh-pages "${INFRASTATISTICS_LOCATION}"
-        rm infra-statistics-gh-pages.zip
-        '''
+        sh './retrieve-infra-statistics-data.sh'
       }
     }
 

--- a/Jenkinsfile_previews
+++ b/Jenkinsfile_previews
@@ -33,12 +33,7 @@ pipeline {
 
     stage('Retrieve data from infra-statistics') {
       steps {
-        sh '''
-        curl --silent --fail --output infra-statistics-gh-pages.zip --location "https://github.com/jenkins-infra/infra-statistics/archive/refs/heads/gh-pages.zip"
-        unzip -n infra-statistics-gh-pages.zip
-        mv infra-statistics-gh-pages "${INFRASTATISTICS_LOCATION}"
-        rm infra-statistics-gh-pages.zip
-        '''
+        sh './retrieve-infra-statistics-data.sh'
       }
     }
 

--- a/Jenkinsfile_previews
+++ b/Jenkinsfile_previews
@@ -10,6 +10,10 @@ pipeline {
     label 'linux-arm64-docker || arm64linux'
   }
 
+  environment {
+    INFRASTATISTICS_LOCATION = 'src/data/infra-statistics'
+  }
+
   stages {
     stage('Install dependencies') {
       when {
@@ -23,6 +27,17 @@ pipeline {
         sh '''
         asdf install
         npm install
+        '''
+      }
+    }
+
+    stage('Retrieve data from infra-statistics') {
+      steps {
+        sh '''
+        curl --silent --fail --output infra-statistics-gh-pages.zip --location "https://github.com/jenkins-infra/infra-statistics/archive/refs/heads/gh-pages.zip"
+        unzip -n infra-statistics-gh-pages.zip
+        mv infra-statistics-gh-pages "${INFRASTATISTICS_LOCATION}"
+        rm infra-statistics-gh-pages.zip
         '''
       }
     }

--- a/README.md
+++ b/README.md
@@ -40,10 +40,7 @@ To build the website locally, follow these steps:
     ```sh
     git clone https://github.com/jenkins-infra/stats.jenkins.io.git
     cd stats.jenkins.io
-    curl --fail --output infra-statistics-gh-pages.zip --location "https://github.com/jenkins-infra/infra-statistics/archive/refs/heads/gh-pages.zip"
-    unzip infra-statistic-gh-pages.zip
-    mv infra-statistics-gh-pages src/data/infra-statistics
-    rm infra-statistics-gh-pages.zip
+    ./retrieve-infra-statistics-data.sh
     ```
 
 2. **Install dependencies:**

--- a/README.md
+++ b/README.md
@@ -35,11 +35,15 @@ If you are developing a production application, we recommend updating the config
 
 To build the website locally, follow these steps:
 
-1. **Clone the repository:**
+1. **Clone the repository and retrieve data from infra-statistics:**
 
     ```sh
     git clone https://github.com/jenkins-infra/stats.jenkins.io.git
     cd stats.jenkins.io
+    curl --fail --output infra-statistics-gh-pages.zip --location "https://github.com/jenkins-infra/infra-statistics/archive/refs/heads/gh-pages.zip"
+    unzip infra-statistic-gh-pages.zip
+    mv infra-statistics-gh-pages src/data/infra-statistics
+    rm infra-statistics-gh-pages.zip
     ```
 
 2. **Install dependencies:**

--- a/retrieve-infra-statistics-data.sh
+++ b/retrieve-infra-statistics-data.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -x
+
+command -v "curl" >/dev/null || { echo "[ERROR] no 'curl' command found."; exit 1; }
+command -v "unzip" >/dev/null || { echo "[ERROR] no 'unzip' command found."; exit 1; }
+
+INFRASTATISTICS_LOCATION="${INFRASTATISTICS_LOCATION:-src/data/infra-statistics}"
+
+curl --silent --fail --output infra-statistics-gh-pages.zip --location "https://github.com/jenkins-infra/infra-statistics/archive/refs/heads/gh-pages.zip"
+# Decompress silently and overwrite existing files
+unzip -q -o infra-statistics-gh-pages.zip
+mv infra-statistics-gh-pages "${INFRASTATISTICS_LOCATION}"
+rm infra-statistics-gh-pages.zip


### PR DESCRIPTION
This PR retrieves infra-statistics content from its gh-pages branch using https://github.com/jenkins-infra/infra-statistics/archive/refs/heads/gh-pages.zip, then decompress it into `./src/data/infra-statistics`.

This location is globally accessible via the `INFRASTATISTICS_LOCATION` environment variable.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4151#issuecomment-2199687823