### PR TITLE
fix: fix dom issue

### DIFF
--- a/src/components/PluginTrends/Layout/PluginCard.tsx
+++ b/src/components/PluginTrends/Layout/PluginCard.tsx
@@ -63,7 +63,11 @@ const PluginCard: React.FC<PluginCardProps> = ({ plugin }) => {
                                 {totalInstallationsK}
                             </Typography>
                         </Box>
-                        <CardMedia>
+                        <CardMedia
+                            sx={{
+                                height: '100px',
+                            }}
+                        >
                             {plugin.chartData ? (
                                 <PluginCardChart data={plugin.chartData} />
                             ) : (


### PR DESCRIPTION
"[ECharts] Can't get DOM width or height. Please check dom.clientWidth and dom.clientHeight. They should not be 0.For example, you may need to call this in the callback of window.onload."

This issue was occurring because the parent container did not have a defined height. this is now fixed.

fixes #72 