### PR TITLE
feat(data): add fetch step for dep-graph data to ```retrieve-infra-statistics-data.sh``` file

### DIFF
--- a/retrieve-infra-statistics-data.sh
+++ b/retrieve-infra-statistics-data.sh
@@ -9,8 +9,12 @@ command -v "unzip" >/dev/null || { echo "[ERROR] no 'unzip' command found."; exi
 
 INFRASTATISTICS_LOCATION="${INFRASTATISTICS_LOCATION:-src/data/infra-statistics}"
 
+# Fetch infra-statistics repository zip and extract it
 curl --silent --fail --output infra-statistics-gh-pages.zip --location "https://github.com/jenkins-infra/infra-statistics/archive/refs/heads/gh-pages.zip"
-# Decompress silently and overwrite existing files
 unzip -q -o infra-statistics-gh-pages.zip
 mv infra-statistics-gh-pages "${INFRASTATISTICS_LOCATION}"
 rm infra-statistics-gh-pages.zip
+
+# Fetch update-center.actual.json
+curl --silent --fail --output "${INFRASTATISTICS_LOCATION}/update-center.actual.json" --location "https://updates.jenkins.io/current/update-center.actual.json"
+

--- a/retrieve-infra-statistics-data.sh
+++ b/retrieve-infra-statistics-data.sh
@@ -17,4 +17,3 @@ rm infra-statistics-gh-pages.zip
 
 # Fetch update-center.actual.json
 curl --silent --fail --output "${INFRASTATISTICS_LOCATION}/update-center.actual.json" --location "https://updates.jenkins.io/current/update-center.actual.json"
-


### PR DESCRIPTION
This PR adds a step to the retrieve-infra-statistics-data.sh file to retrieve the update-center.json file that is needed to populate the dependency graph.

as @lemeurherve suggested on #106, we should keep the fetching of data separate from the frontend repo. 

This would simply add a step during the build process to fetch the data, and store it in the same repo as the rest of the data. 

needed for #114 / closes #106 



