### PR TITLE
feat: add optional tag only when optional = true

### DIFF
--- a/src/pages/dep-graph/index.tsx
+++ b/src/pages/dep-graph/index.tsx
@@ -237,7 +237,7 @@ const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(({ node }, ref) =
                     <ul>
                         {node.dependencies.map((dep) => (
                             <li key={dep.name}>
-                                {dep.name} (version: {dep.version} / optional: {dep.optional.toString()})
+                                {dep.name} (version: {dep.version}) {dep.optional ? ' -- OPTIONAL' : ''}
                             </li>
                         ))}
                     </ul>


### PR DESCRIPTION
Per @krisstern meeting with Mark - adds an optional flag only when optional = true. Otherwise just lists the rep. 

![Screenshot 2024-08-05 at 1 20 16 PM](https://github.com/user-attachments/assets/5ccf2945-c4aa-40f7-8a65-e3e9a3b7de30)
