### PR TITLE
fix: serve all static files previously accessible from stats.jenkins.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ dist-ssr
 
 # infra-statistics
 src/data/infra-statistics
+public/plugin-installation-trend
+public/jenkins-stats
+public/pluginversions
 
 # bundle analyzer
 bundle-analysis.html

--- a/retrieve-infra-statistics-data.sh
+++ b/retrieve-infra-statistics-data.sh
@@ -15,5 +15,10 @@ unzip -q -o infra-statistics-gh-pages.zip
 mv infra-statistics-gh-pages "${INFRASTATISTICS_LOCATION}"
 rm infra-statistics-gh-pages.zip
 
+# Copy folders over public folder to serve their static files
+for dir in jenkins-stats plugin-installation-trend pluginversions; do
+    cp -r "${INFRASTATISTICS_LOCATION}/${dir}" public/
+done
+
 # Fetch update-center.actual.json
 curl --silent --fail --output "${INFRASTATISTICS_LOCATION}/update-center.actual.json" --location "https://updates.jenkins.io/current/update-center.actual.json"


### PR DESCRIPTION
This PR allows to continue serving all static files that were previously available from stats.jenkins.io and consumed from many places.

I've kept it KISS, copying over files (.gitignored) into the `/public` folder so they're serve without any more change.
This can be refined later if deemed important, the goal here is to restore broken URLs.

Tested locally.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4132#issuecomment-2347009570
- https://github.com/jenkins-infra/helpdesk/issues/4132#issuecomment-2348625563

cc @dduportal @krisstern @timja 