### PR TITLE
fix: resolve search functionality across multiple pages

### DIFF
--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,8 +1,12 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { IPluginData } from '../types/types'
 
-const usePagination = (data: IPluginData[], itemsPerPage: number) => {
+const usePagination = (data: IPluginData[], itemsPerPage: number, searchTerm: string) => {
     const [page, setPage] = useState<number>(1)
+
+    useEffect(() => {
+        setPage(1)
+    }, [searchTerm])
 
     const handlePageChange = (_event: React.ChangeEvent<unknown>, value: number) => {
         setPage(value)

--- a/src/pages/plugin-trends/index.tsx
+++ b/src/pages/plugin-trends/index.tsx
@@ -14,6 +14,7 @@ import {
     Autocomplete,
 } from '@mui/material'
 import useSortPlugins from '../../hooks/useSortPlugins'
+import { SortOption } from '../../types/types';
 import useFetchPlugins from '../../hooks/useFetchPlugins'
 import useSearchPlugins from '../../hooks/useSearchPlugins'
 import usePagination from '../../hooks/usePagination'

--- a/src/pages/plugin-trends/index.tsx
+++ b/src/pages/plugin-trends/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import {
     Paper,
     Stack,
@@ -26,9 +26,24 @@ const PluginTrends: React.FC = () => {
     const { plugins, loading } = useFetchPlugins()
     const { filteredPlugins } = useSearchPlugins(plugins, searchTerm)
     const { sortOption, setSortOption } = useSortPlugins(filteredPlugins)
-    const itemsPerPage = 72
 
-    const { page, handlePageChange, paginatedData, totalPages } = usePagination(filteredPlugins, itemsPerPage)
+    const itemsPerPage = 72
+    const totalPages = Math.ceil(filteredPlugins.length / itemsPerPage) // Calculate total pages based on filtered plugins
+
+    const [page, setPage] = useState<number>(1)
+
+    useEffect(() => {
+        setPage(1)
+    }, [searchTerm])
+
+    const handlePageChange = (event: React.ChangeEvent<unknown>, value: number) => {
+        setPage(value)
+    }
+
+    const paginatedData = useMemo(() => {
+        const startIndex = (page - 1) * itemsPerPage
+        return filteredPlugins.slice(startIndex, startIndex + itemsPerPage)
+    }, [filteredPlugins, page, itemsPerPage])
 
     const pluginOptions = useMemo(() => filteredPlugins.map((plugin) => plugin.id), [filteredPlugins])
     const filterOptions = (options: string[], { inputValue }: { inputValue: string }) => {

--- a/src/pages/plugin-trends/index.tsx
+++ b/src/pages/plugin-trends/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from 'react'
+import { useState, useMemo } from 'react'
 import {
     Paper,
     Stack,
@@ -14,11 +14,10 @@ import {
     Autocomplete,
 } from '@mui/material'
 import useSortPlugins from '../../hooks/useSortPlugins'
-import usePagination from '../../hooks/usePagination'
-import PluginCard from '../../components/PluginTrends/Layout/PluginCard'
-import { SortOption } from '../../types/types'
 import useFetchPlugins from '../../hooks/useFetchPlugins'
 import useSearchPlugins from '../../hooks/useSearchPlugins'
+import usePagination from '../../hooks/usePagination'
+import PluginCard from '../../components/PluginTrends/Layout/PluginCard'
 import BackToHome from '../../components/Layout/BackToHome'
 
 const PluginTrends: React.FC = () => {
@@ -28,22 +27,8 @@ const PluginTrends: React.FC = () => {
     const { sortOption, setSortOption } = useSortPlugins(filteredPlugins)
 
     const itemsPerPage = 72
-    const totalPages = Math.ceil(filteredPlugins.length / itemsPerPage) // Calculate total pages based on filtered plugins
 
-    const [page, setPage] = useState<number>(1)
-
-    useEffect(() => {
-        setPage(1)
-    }, [searchTerm])
-
-    const handlePageChange = (event: React.ChangeEvent<unknown>, value: number) => {
-        setPage(value)
-    }
-
-    const paginatedData = useMemo(() => {
-        const startIndex = (page - 1) * itemsPerPage
-        return filteredPlugins.slice(startIndex, startIndex + itemsPerPage)
-    }, [filteredPlugins, page, itemsPerPage])
+    const { page, handlePageChange, paginatedData, totalPages } = usePagination(filteredPlugins, itemsPerPage, searchTerm)
 
     const pluginOptions = useMemo(() => filteredPlugins.map((plugin) => plugin.id), [filteredPlugins])
     const filterOptions = (options: string[], { inputValue }: { inputValue: string }) => {


### PR DESCRIPTION
Fixes: #184 
Implemented a fix to ensure that the search functionality for plugins works correctly across all pagination pages. The search term now resets the current page to 1, preventing users from seeing empty results when searching from a non-initial page. 

This change ensures that search results are accessible no matter where the user is in the pagination.

https://github.com/user-attachments/assets/2451ee14-d771-4edb-bd97-8d3c90502e51

