### PR TITLE
Enhancement feature: Sort year by descending order instead of ascending order

### DIFF
--- a/src/components/StatsInDetail/Layout/Drawer.tsx
+++ b/src/components/StatsInDetail/Layout/Drawer.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import {
     Box,
     Typography,
@@ -93,6 +93,16 @@ const Drawer: React.FC<DrawerProps> = ({
         toggleSidebar()
     }
 
+    const sortedYearList = useMemo(() => {
+        return Array.from(
+            new Set(
+                data
+                .map((row) => row.year)
+                .sort((y1, y2) => parseInt(y2) - parseInt(y1))
+            )
+        );
+    }, []);
+
     const DrawerContent = (
         <List>
             <StyledAccordion defaultExpanded>
@@ -125,7 +135,7 @@ const Drawer: React.FC<DrawerProps> = ({
                         >
                             <ListText primary="All Data" />
                         </ListButton>
-                        {[...new Set(data.map((row) => row.year))].map((year) => (
+                        {sortedYearList.map((year) => (
                             <ListButton
                                 key={year}
                                 selected={selectedYear === year}


### PR DESCRIPTION
Fixes: https://github.com/jenkins-infra/stats.jenkins.io/issues/194

Before:
![image](https://github.com/user-attachments/assets/65a2bb64-86a2-450d-9a26-dcdfd90345f7)


After:
![image](https://github.com/user-attachments/assets/c68a4ee6-c7e4-4cd0-a336-d8d53cd1a053)
