### PR TITLE
Bugfix/fix filtering pagination

### DIFF
--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,24 +1,12 @@
-import { useState, useEffect } from 'react'
 import { IPluginData } from '../types/types'
 
-const usePagination = (data: IPluginData[], itemsPerPage: number, searchTerm: string) => {
-    const [page, setPage] = useState<number>(1)
-
-    useEffect(() => {
-        setPage(1)
-    }, [searchTerm])
-
-    const handlePageChange = (_event: React.ChangeEvent<unknown>, value: number) => {
-        setPage(value)
-    }
-
+const usePagination = (data: IPluginData[], itemsPerPage: number, page: number) => {
+    const totalPages = Math.ceil(data.length / itemsPerPage)
     const paginatedData = data.slice((page - 1) * itemsPerPage, page * itemsPerPage)
 
     return {
-        page,
-        handlePageChange,
         paginatedData,
-        totalPages: Math.ceil(data.length / itemsPerPage),
+        totalPages,
     }
 }
 

--- a/src/hooks/usePaginationState.ts
+++ b/src/hooks/usePaginationState.ts
@@ -1,0 +1,13 @@
+import { useState } from 'react'
+
+const usePaginationState = (initialPage = 1) => {
+    const [page, setPage] = useState<number>(initialPage)
+
+    const handlePageChange = (_event: React.ChangeEvent<unknown>, value: number) => {
+        setPage(value)
+    }
+
+    return { page, setPage, handlePageChange }
+}
+
+export default usePaginationState

--- a/src/pages/plugin-trends/index.tsx
+++ b/src/pages/plugin-trends/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useRef, useEffect } from 'react'
 import {
     Paper,
     Stack,
@@ -18,23 +18,39 @@ import { SortOption } from '../../types/types';
 import useFetchPlugins from '../../hooks/useFetchPlugins'
 import useSearchPlugins from '../../hooks/useSearchPlugins'
 import usePagination from '../../hooks/usePagination'
+import usePaginationState from '../../hooks/usePaginationState'
 import PluginCard from '../../components/PluginTrends/Layout/PluginCard'
 import BackToHome from '../../components/Layout/BackToHome'
 
 const PluginTrends: React.FC = () => {
     const [searchTerm, setSearchTerm] = useState<string>('')
+    const { page, setPage, handlePageChange } = usePaginationState()
+    const [lastPage, setLastPage] = useState<number>(1)
     const { plugins, loading } = useFetchPlugins()
     const { filteredPlugins } = useSearchPlugins(plugins, searchTerm)
     const { sortOption, setSortOption } = useSortPlugins(filteredPlugins)
 
     const itemsPerPage = 72
 
-    const { page, handlePageChange, paginatedData, totalPages } = usePagination(filteredPlugins, itemsPerPage, searchTerm)
+    const { paginatedData, totalPages } = usePagination(filteredPlugins, itemsPerPage, page)
 
     const pluginOptions = useMemo(() => filteredPlugins.map((plugin) => plugin.id), [filteredPlugins])
     const filterOptions = (options: string[], { inputValue }: { inputValue: string }) => {
         return inputValue.length === 0 ? [] : options
     }
+
+    const prevSearchTerm = useRef<string>('')
+
+    useEffect(() => {
+        if (prevSearchTerm.current === '' && searchTerm !== '') {
+            setLastPage(page)
+            setPage(1)
+        } else if (prevSearchTerm.current !== '' && searchTerm === '') {
+            setPage(lastPage)
+        }
+
+        prevSearchTerm.current = searchTerm
+    }, [lastPage, page, searchTerm, setPage])
 
     return (
         <>


### PR DESCRIPTION
**What**
Fixes: https://github.com/jenkins-infra/stats.jenkins.io/issues/184

**Tests**
In the plugin-trends page:
- [x] If the user types a keyword and searches while in page `x`, when they clear the search, they return to page `x`
- [x] If the user types a keyword and searches while in page `x`, and the result has more than one page, the pagination for that search begins in page 1
- [x] If the user types a keyword and searches while in page `x`, and the result has more than one page and the user navigates to a different page, when they clear the search, they return to page `x`