### PR TITLE
Sorted the data in descending order

### DIFF
--- a/src/components/StatsInDetail/Charts/StatisticsTable.tsx
+++ b/src/components/StatsInDetail/Charts/StatisticsTable.tsx
@@ -33,6 +33,17 @@ const StatisticsTable: React.FC<StatisticsTableProps> = ({ year }) => {
 
     const filteredData = year === 'all' ? data : data.filter((row) => row.year === year)
 
+    // Optimized function to sort data by year and month in descending order
+    const sortData = (dataArray: { year: string; month: string }[]): { year: string; month: string }[] => {
+        return dataArray.sort((a, b) => {
+            const yearDiff = Number(b.year) - Number(a.year);
+            return yearDiff !== 0 ? yearDiff : Number(b.month) - Number(a.month);
+        });
+    };
+
+    // Sorting the filtered data
+    const sortedData = sortData(filteredData);
+
     return (
         <>
             <TableContainer
@@ -116,7 +127,7 @@ const StatisticsTable: React.FC<StatisticsTableProps> = ({ year }) => {
                             },
                         }}
                     >
-                        {filteredData.map((row, index) => (
+                        {sortedData.map((row, index) => (
                             <TableRow key={index}>
                                 <TableCell align="center">{row.year}</TableCell>
                                 <TableCell align="center">


### PR DESCRIPTION
Fixes: https://github.com/jenkins-infra/stats.jenkins.io/issues/200

Before:
<img width="1714" alt="image" src="https://github.com/user-attachments/assets/3fceaab1-27e9-4d78-9510-83f7ac256c38">

After:
<img width="1715" alt="image" src="https://github.com/user-attachments/assets/7b00977f-6047-4e9b-a222-bf4d3d256fc9">

Changes Made:

Sorts data Monthly Analysis in descending order

Please review this PR and let me know if any changes are needed.