### PR TITLE
Add opengraph meta tags to add details to social media previews

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,8 +18,8 @@
         <meta name="twitter:image:alt" content="Jenkins Statistics Page" />
 
         <!--  Non-Essential, But Required for Analytics,  -->
-        <meta property="fb:app_id" content="your_app_id" />
-        <meta name="twitter:site" content="@twitter-handle" />
+        <!-- <meta property="fb:app_id" content="your_app_id" /> -->
+        <!-- <meta name="twitter:site" content="@twitter-handle" /> -->
 
         <title>Jenkins Statistics</title>
 

--- a/index.html
+++ b/index.html
@@ -10,9 +10,9 @@
 
         <meta property="og:title" content="Jenkins Statistics" />
         <meta property="og:type" content="website"/>
-        <meta property="og:image" content="https://www.jenkins.io/images/logos/jenkins/jenkins.svg" />
+        <meta property="og:image" content="https://raw.githubusercontent.com/jenkins-infra/jenkins.io/refs/heads/master/content/images/gsoc/opengraph.png" />
         <meta property="og:url" content="https://stats.jenkins.io" />
-        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:card" content="summary_large_image" />
         <meta property="og:description" content="This site shows different Statistical data of different plugins in the Jenkins Ecosystem " />
         <meta property="og:site_name" content="Jenkins Statistics" />
         <meta name="twitter:image:alt" content="Jenkins Statistics Page" />

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
-        <link href="/favicon.ico" rel="shortcut icon" type="image/x-icon" />
+        <link href="/favicon.ico" rel="icon" type="image/x-icon" />
         <link href="/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180" />
         <link href="/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png" />
         <link href="/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png" />

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
         <meta property="og:type" content="website"/>
         <meta property="og:image" content="https://www.jenkins.io/images/logos/jenkins/jenkins.svg" />
         <meta property="og:url" content="https://stats.jenkins.io" />
-        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:card" content="summary" />
         <meta property="og:description" content="This site shows different Statistical data of different plugins in the Jenkins Ecosystem " />
         <meta property="og:site_name" content="Jenkins Statistics" />
         <meta name="twitter:image:alt" content="Jenkins Statistics Page" />

--- a/index.html
+++ b/index.html
@@ -2,12 +2,27 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
-        <link href='/favicon.ico' rel='shortcut icon' type='image/x-icon'>
-        <link href='/apple-touch-icon.png' rel='apple-touch-icon' sizes='180x180'>
-        <link href='/favicon-32x32.png' rel='icon' sizes='32x32' type='image/png'>
-        <link href='/favicon-16x16.png' rel='icon' sizes='16x16' type='image/png'>
+        <link href="/favicon.ico" rel="shortcut icon" type="image/x-icon" />
+        <link href="/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180" />
+        <link href="/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png" />
+        <link href="/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+        <meta property="og:title" content="Jenkins Statistics" />
+        <meta property="og:type" content="website"/>
+        <meta property="og:image" content="https://www.jenkins.io/images/logos/jenkins/jenkins.svg" />
+        <meta property="og:url" content="https://stats.jenkins.io" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta property="og:description" content="This site shows different Statistical data of different plugins in the Jenkins Ecosystem " />
+        <meta property="og:site_name" content="Jenkins Statistics" />
+        <meta name="twitter:image:alt" content="Jenkins Statistics Page" />
+
+        <!--  Non-Essential, But Required for Analytics,  -->
+        <meta property="fb:app_id" content="your_app_id" />
+        <meta name="twitter:site" content="@twitter-handle" />
+
         <title>Jenkins Statistics</title>
+
         <!-- Load necessary scripts for jio-navbar -->
         <script type="module" src="https://unpkg.com/@jenkinsci/jenkins-io-components?module"></script>
         <script src="https://unpkg.com/@webcomponents/webcomponentsjs@2.6.0/webcomponents-loader.js"></script>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
         <meta property="og:site_name" content="Jenkins Statistics" />
         <meta name="twitter:image:alt" content="Jenkins Statistics" />
 
-        <!--  Non-Essential, But Required for Analytics,  -->
+        <!--  Non-essential, but required for analytics  -->
         <!-- <meta property="fb:app_id" content="your_app_id" /> -->
         <!-- <meta name="twitter:site" content="@twitter-handle" /> -->
 

--- a/index.html
+++ b/index.html
@@ -13,9 +13,9 @@
         <meta property="og:image" content="https://raw.githubusercontent.com/jenkins-infra/jenkins.io/refs/heads/master/content/images/gsoc/opengraph.png" />
         <meta property="og:url" content="https://stats.jenkins.io" />
         <meta name="twitter:card" content="summary_large_image" />
-        <meta property="og:description" content="This site shows different Statistical data of different plugins in the Jenkins Ecosystem " />
+        <meta property="og:description" content="This site shows statistics related to Jenkins infrastructure" />
         <meta property="og:site_name" content="Jenkins Statistics" />
-        <meta name="twitter:image:alt" content="Jenkins Statistics Page" />
+        <meta name="twitter:image:alt" content="Jenkins Statistics" />
 
         <!--  Non-Essential, But Required for Analytics,  -->
         <!-- <meta property="fb:app_id" content="your_app_id" /> -->


### PR DESCRIPTION
Closes #226 

Added opengraph metadata support to allow social media preview. 

@krisstern 
You can change the description and title according to what you see fit.

