### PR TITLE
fix: replace "master" with "main"

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 
         <meta property="og:title" content="Jenkins Statistics" />
         <meta property="og:type" content="website"/>
-        <meta property="og:image" content="https://raw.githubusercontent.com/jenkins-infra/jenkins.io/refs/heads/master/content/images/gsoc/opengraph.png" />
+        <meta property="og:image" content="https://raw.githubusercontent.com/jenkins-infra/jenkins.io/refs/heads/main/content/images/gsoc/opengraph.png" />
         <meta property="og:url" content="https://stats.jenkins.io" />
         <meta name="twitter:card" content="summary_large_image" />
         <meta property="og:description" content="This site shows statistics related to Jenkins infrastructure" />


### PR DESCRIPTION
Extension of [#7841](https://github.com/jenkins-infra/jenkins.io/pull/7841)

This PR is basically an extension of our primary PR in the jenkins.io repo.
We are on a larger mission to replace all master references to main .
This findings are of Kevin Sir ([his comment regarding this](https://github.com/jenkins-infra/jenkins.io/pull/7841#issuecomment-2755502715)) . Much thankful to him for his support