### PR TITLE
Revert "refactor: consolidate infra-statistics data to public/ directory"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,11 @@ dist-ssr
 *.sln
 *.sw?
 
-# infra-statistics data (now consolidated in public/)
-public/infra-statistics
+# infra-statistics
+src/data/infra-statistics
+public/plugin-installation-trend
+public/jenkins-stats
+public/pluginversions
 
 # bundle analyzer
 bundle-analysis.html

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
   }
 
   environment {
-    INFRASTATISTICS_LOCATION = 'public/infra-statistics'
+    INFRASTATISTICS_LOCATION = 'src/data/infra-statistics'
   }
 
   stages {

--- a/Jenkinsfile_previews
+++ b/Jenkinsfile_previews
@@ -11,7 +11,7 @@ pipeline {
   }
 
   environment {
-    INFRASTATISTICS_LOCATION = 'public/infra-statistics'
+    INFRASTATISTICS_LOCATION = 'src/data/infra-statistics'
   }
 
   stages {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,8 +24,6 @@ export default [{
         "docs/",
         "jsdoc/",
         "dist/",
-        "public/infra-statistics/",
-        "bundle-analysis.html",
     ],
 }, ...fixupConfigRules(compat.extends(
     "eslint:recommended",

--- a/retrieve-infra-statistics-data.sh
+++ b/retrieve-infra-statistics-data.sh
@@ -7,13 +7,18 @@ set -x
 command -v "curl" >/dev/null || { echo "[ERROR] no 'curl' command found."; exit 1; }
 command -v "unzip" >/dev/null || { echo "[ERROR] no 'unzip' command found."; exit 1; }
 
-INFRASTATISTICS_LOCATION="${INFRASTATISTICS_LOCATION:-public/infra-statistics}"
+INFRASTATISTICS_LOCATION="${INFRASTATISTICS_LOCATION:-src/data/infra-statistics}"
 
 # Fetch infra-statistics repository zip and extract it
 curl --silent --fail --output infra-statistics-gh-pages.zip --location "https://github.com/jenkins-infra/infra-statistics/archive/refs/heads/gh-pages.zip"
 unzip -q -o infra-statistics-gh-pages.zip
 mv infra-statistics-gh-pages "${INFRASTATISTICS_LOCATION}"
 rm infra-statistics-gh-pages.zip
+
+# Copy folders over public folder to serve their static files
+for dir in jenkins-stats plugin-installation-trend pluginversions; do
+    cp -r "${INFRASTATISTICS_LOCATION}/${dir}" public/
+done
 
 # Fetch update-center.actual.json
 curl --silent --fail --output "${INFRASTATISTICS_LOCATION}/update-center.actual.json" --location "https://updates.jenkins.io/current/update-center.actual.json"

--- a/src/hooks/useCSVData.ts
+++ b/src/hooks/useCSVData.ts
@@ -8,7 +8,7 @@ const useCSVData = (csvFileName: string) => {
     useEffect(() => {
         const fetchData = async () => {
             try {
-                const fileUrl = `/infra-statistics/jenkins-stats/svg/${csvFileName}.csv`;
+                const fileUrl = new URL(`../data/infra-statistics/jenkins-stats/svg/${csvFileName}.csv`, import.meta.url).href;
                 const response = await fetch(fileUrl);
                 if (!response.ok) {
                     throw new Error(`Failed to fetch CSV file: ${response.statusText}`);

--- a/src/hooks/useFetchPlugins.ts
+++ b/src/hooks/useFetchPlugins.ts
@@ -34,7 +34,10 @@ const useFetchPlugins = (): UseFetchPluginsResult => {
 
             const results = await Promise.allSettled(
                 namesToFetch.map(async (name): Promise<IPluginData> => {
-                    const fileUrl = `/infra-statistics/plugin-installation-trend/${name}.stats.json`;
+                    const fileUrl = new URL(
+                        `../data/infra-statistics/plugin-installation-trend/${name}.stats.json`,
+                        import.meta.url
+                    ).href;
                     const response = await fetch(fileUrl, { signal });
                     if (!response.ok) {
                         throw new Error(`JSON file for plugin with id "${name}" not found`);

--- a/src/hooks/useGetDependencyGraphData.ts
+++ b/src/hooks/useGetDependencyGraphData.ts
@@ -9,7 +9,7 @@ const usePluginData = () => {
     useEffect(() => {
         const fetchPlugins = async () => {
             try {
-                const fileUrl = `/infra-statistics/update-center.actual.json`
+                const fileUrl = new URL(`../data/infra-statistics/update-center.actual.json`, import.meta.url).href
                 const response = await fetch(fileUrl)
                 if (!response.ok) {
                     throw new Error('Network response was not ok')

--- a/src/hooks/useGetPluginNamesAndCount.ts
+++ b/src/hooks/useGetPluginNamesAndCount.ts
@@ -8,7 +8,7 @@ const usePluginData = () => {
     useEffect(() => {
         const fetchPluginData = async () => {
             try {
-                const fileUrl = '/infra-statistics/plugin-installation-trend/latestNumbers.json';
+                const fileUrl = new URL('../data/infra-statistics/plugin-installation-trend/latestNumbers.json', import.meta.url).href;
                 const response = await fetch(fileUrl);
                 if (!response.ok) {
                     throw new Error('Failed to fetch plugin data');

--- a/src/hooks/useGetPluginVersionData.ts
+++ b/src/hooks/useGetPluginVersionData.ts
@@ -8,7 +8,7 @@ const useGetPluginVersionData = () => {
     useEffect(() => {
         const fetchData = async () => {
             try {
-                const fileUrl = `/infra-statistics/plugin-installation-trend/jenkins-version-per-plugin-version.json`;
+                const fileUrl = new URL(`../data/infra-statistics/plugin-installation-trend/jenkins-version-per-plugin-version.json`, import.meta.url).href;
                 const response = await fetch(fileUrl);
                 if (!response.ok) {
                     throw new Error(`Version data not found`);

--- a/src/hooks/useJVMData.ts
+++ b/src/hooks/useJVMData.ts
@@ -19,7 +19,7 @@ const useJVMData = () => {
     useEffect(() => {
         const parseJVMData = async () => {
             try {
-                const fileUrl = '/infra-statistics/plugin-installation-trend/jvms.json';
+                const fileUrl = new URL('../data/infra-statistics/plugin-installation-trend/jvms.json', import.meta.url).href;
                 const response = await fetch(fileUrl);
                 if (!response.ok) {
                     throw new Error('Failed to fetch JVM data');


### PR DESCRIPTION
Reverts jenkins-infra/stats.jenkins.io#648

To be merged asap please.

If to be reintroduced, please take the time to review and plan how not to break existing links and consumers.

Caused:
- https://github.com/jenkins-infra/helpdesk/issues/4988
- https://github.com/jenkins-infra/helpdesk/issues/4991

Related:
- https://github.com/jenkins-infra/stats.jenkins.io/issues/649

Ref:
- https://github.com/jenkins-infra/stats.jenkins.io/pull/648#discussion_r2794302627
