### PR TITLE
Improve retrieve-infra-statistics-data.sh with good practices

### DIFF
--- a/retrieve-infra-statistics-data.sh
+++ b/retrieve-infra-statistics-data.sh
@@ -1,22 +1,27 @@
 #!/bin/bash
 
-set -o nounset
-set -o errexit
-set -x
+set -euxo pipefail
 
 command -v "curl" >/dev/null || { echo "[ERROR] no 'curl' command found."; exit 1; }
 command -v "unzip" >/dev/null || { echo "[ERROR] no 'unzip' command found."; exit 1; }
 
 INFRASTATISTICS_LOCATION="${INFRASTATISTICS_LOCATION:-src/data/infra-statistics}"
 
+trap 'rm -f infra-statistics-gh-pages.zip' EXIT
+
 # Fetch infra-statistics repository zip and extract it
 curl --silent --fail --output infra-statistics-gh-pages.zip --location "https://github.com/jenkins-infra/infra-statistics/archive/refs/heads/gh-pages.zip"
 unzip -q -o infra-statistics-gh-pages.zip
+rm -rf "${INFRASTATISTICS_LOCATION}"
 mv infra-statistics-gh-pages "${INFRASTATISTICS_LOCATION}"
 rm infra-statistics-gh-pages.zip
 
 # Copy folders over public folder to serve their static files
 for dir in jenkins-stats plugin-installation-trend pluginversions; do
+    if [ ! -d "${INFRASTATISTICS_LOCATION}/${dir}"]; then
+        echo "[ERROR] Expected directory not found: ${dir}"
+        exit 1
+    fi
     cp -r "${INFRASTATISTICS_LOCATION}/${dir}" public/
 done
 


### PR DESCRIPTION
Resolves #663  
Small improvements of good practices to the retrieve-infra-statistics-data.sh 

- Replace separate 'set -o' files with 'set -euxo pipefail'. There are no pipes currently, but it's good to add now, if at all we add pipes in the future.
- Add 'trap' to clean up 'infra-statistics-gh-pages.zip' on unexpected failure, prevents leftover files if the script exists early.
- Add 'rm -rf' before 'mv' to safely handle cases where the destination directory already exists from a previous run.
- Add an existence check in the 'for' loop so if an unexpected directory is missing from the extracted zip, the script fails loudly with a clear error message.