### PR TITLE
chore(Jenkinsfile_previews/documentation): replace npm install with npm ci

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ You can contribute to `stats.jenkins.io` in several ways:
     ```
 5. **Install dependencies**:
     ```console
-    npm install
+    npm ci
     ```
 6. **Run the project locally**:
     ```console

--- a/Jenkinsfile_previews
+++ b/Jenkinsfile_previews
@@ -25,7 +25,7 @@ pipeline {
       }
       steps {
         sh '''
-        npm install
+        npm ci
         '''
       }
     }

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ To get started with this project, you will need the following installed on your 
 3. **Install dependencies:**
 
     ```sh
-    npm install
+    npm ci
     ```
 
 ## Building the Website Locally


### PR DESCRIPTION
Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5119 

enforcing `npm ci` over `npm install` across CI/CD pipelines for reproducible builds.

- `Jenkinsfile_previews`: `npm install` → `npm ci`
- `CONTRIBUTING.md`: Updated install instructions to use `npm ci`
- `README.md`: Updated install instructions to use `npm ci`
