### PR TITLE
fix: set _redirect rules to get proper status codes

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,4 @@
-/* /index.html 200
+/statistics /index.html 200
+/plugin-trends /index.html 200
+/plugin-versions /index.html 200
+/dep-graph /index.html 200


### PR DESCRIPTION
### Description 
This pr sets _redirects rules for the routes present in this application 
```
/statistics /index.html 200
/plugin-trends /index.html 200
/plugin-versions /index.html 200
/dep-graph /index.html 200
```
if any other non-existing request won’t match a rule then netlify will return 404 Not Found.

Note: I have tested these changes by deploying the branch on netlify i.e. https://papaya-dasik-e9c18d.netlify.app/
here are the results: 
<img width="787" height="232" alt="image" src="https://github.com/user-attachments/assets/bec1c000-8e2d-4536-99d1-298feb9d5d28" />

<img width="859" height="254" alt="image" src="https://github.com/user-attachments/assets/62dad9d9-dc4f-46e8-aa28-e8cccc91b2e7" />


fixes #671 